### PR TITLE
Regex for literals should allow upper-case letters.

### DIFF
--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -148,7 +148,7 @@ class Lexer
   STAR                = /^\*/
   SEPARATOR           = /^,/
   WHITESPACE          = /^[ \n\r]+/
-  LITERAL             = /^`?([a-z_][a-z0-9_]{0,})`?/i
+  LITERAL             = /^`?([A-Za-z_][A-Za-z0-9_]{0,})`?/i
   PARAMETER           = /^\$[0-9]+/
   NUMBER              = /^[0-9]+(\.[0-9]+)?/
   STRING              = /^'([^\\']*(?:\\.[^\\']*)*)'/


### PR DESCRIPTION
It's far enough down the list that it should mess with the other tokens.