### PR TITLE
Fix the preserveWhitespace option

### DIFF
--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -130,9 +130,9 @@ class Lexer
   whitespaceToken: ->
     return 0 unless match = WHITESPACE.exec(@chunk)
     partMatch = match[0]
-    newlines = partMatch.replace(/[^\n]/, '').length
-    @currentLine += newlines
-    @token(name, partMatch) if @preserveWhitespace
+    @token('WHITESPACE', partMatch) if @preserveWhitespace
+    newlines = partMatch.match(/\n/g, '')
+    @currentLine += newlines?.length || 0
     return partMatch.length
 
   regexEscape: (str) ->


### PR DESCRIPTION
The parser should increment the line count by the number of matched newlines

Instead, the code is counting number of characters remaining after you replace the first non-newline character (`/[^\n]/`), which is wrong. Also, `name` was undefined.
